### PR TITLE
Add ... syntax functionality.

### DIFF
--- a/goat.sh
+++ b/goat.sh
@@ -95,6 +95,9 @@ go() {
     local path
     path="$(echo "$entry" | cut -d'	' -f2)"
 
+    # Check for previous directory syntax
+    path="$(if_dots "$shortcut")"
+
     if [ -z "$path" ]; then
         errcho "ERROR: goat doesn't know where '${shortcut}' should lead to."
         return 1
@@ -104,6 +107,37 @@ go() {
     else
         echo "$path"
     fi
+}
+
+# Detect a shortcut of all .'s and
+# return an appropriate path of form
+# ../../.. etc.
+#
+# If the shortcut is not all .'s, simply
+# returns the shortcut as-is.
+if_dots() {
+  local shortcut="$1"
+  local prev_dir="../"
+  local path
+
+  # Maintain expected functionality of . and ..
+  if [ "$shortcut" = "." -o "$shortcut" = ".." ]; then
+    path=$shortcut
+    echo $path
+    return 0
+  fi
+
+  path="../"
+  for (( i = 2; i<${#shortcut}; i++ )); do
+    if [ "${shortcut:$i:1}" != "." ]; then
+      echo $shortcut
+      return 1
+    else
+      path=$path$prev_dir
+    fi
+  done
+
+  echo $path
 }
 
 # Create a new shortcut

--- a/goat.sh
+++ b/goat.sh
@@ -86,17 +86,22 @@ Usage:
 #   - 1 when there was an error
 go() {
     local shortcut="$1"
-    local entry
-    entry="$(get_entry "$shortcut")"
 
-    # Check if get_entry failed
-    [ "$entry" = "1" ] && return 1
-
+    # Check if the entered shortcut is all dots
     local path
-    path="$(echo "$entry" | cut -d'	' -f2)"
+    local dot_path="$(check_dots "$shortcut")"
+    if [ -n "$dot_path" ]; then
+      path=$dot_path
+    # If not all dots, proceed as usual
+    else
+      local entry
+      entry="$(get_entry "$shortcut")"
 
-    # Check for previous directory syntax
-    path="$(if_dots "$shortcut")"
+      # Check if get_entry failed
+      [ "$entry" = "1" ] && return 1
+
+      path="$(echo "$entry" | cut -d'	' -f2)"
+    fi
 
     if [ -z "$path" ]; then
         errcho "ERROR: goat doesn't know where '${shortcut}' should lead to."
@@ -115,25 +120,32 @@ go() {
 #
 # If the shortcut is not all .'s, simply
 # returns the shortcut as-is.
-if_dots() {
+check_dots() {
   local shortcut="$1"
   local prev_dir="../"
-  local path
+  local path=""
 
   # Maintain expected functionality of . and ..
-  if [ "$shortcut" = "." -o "$shortcut" = ".." ]; then
+  if [ "$shortcut" = '.' -o "$shortcut" = '..' ]; then
     path=$shortcut
     echo $path
     return 0
   fi
+  
+  # Dot-checking.
+  if [ "${shortcut:0:1}" != '.' ]; then
+    echo ''
+    return 1
+  fi
 
-  path="../"
-  for (( i = 2; i<${#shortcut}; i++ )); do
-    if [ "${shortcut:$i:1}" != "." ]; then
-      echo $shortcut
-      return 1
-    else
+  for (( i = 1; i<${#shortcut}; i++ )); do
+    if [ "${shortcut:$i:1}" = '.' ]; then
       path=$path$prev_dir
+      # If a non-dot is found, return empty path
+      # (unknown shortcut)
+    else
+      echo ''
+      return 1
     fi
   done
 


### PR DESCRIPTION
This PR implements the feature requested in issue #17.

**Current Status: Lightly tested in bash, zsh, tcsh, mksh**

I simply check if the shortcut is all dots, and if so, set a properly formatted ("../../../") path string. Also, I made an effort to maintain . and .. as their usual functions - current directory and previous directory, respectively, so as not to confuse the user. If the shortcut is not all dots, it gets passed on to the usual get_entry methodology for retrieving shortcut paths.

This results in the following pattern:

. -> .
.. -> ..
... -> ../..
.... -> ../../..

and so on.

Example usage ('deep' is a shortcut all the way down to folder '8'):
![2016-10-18-201525_379x153_scrot](https://cloud.githubusercontent.com/assets/8472688/19500947/a10902b6-956f-11e6-847c-ca3658c12655.png)
