### PR TITLE
Avoid broken ln on mingw

### DIFF
--- a/goat
+++ b/goat
@@ -174,12 +174,8 @@ mingw_ln()
 {
 	targetpath="$1"
 	destination="$2"
-	#cmd "$destination" "$targetpath"
 	"$GOAT_PATH/mingw_ln.bat" "$destination" "$targetpath"
-exit
-EOF
 }
-
 
 list()
 {

--- a/goat
+++ b/goat
@@ -38,6 +38,15 @@ GOAT_PATH="${GOAT_PATH:-"$HOME/.goat"}"
 
 version=2.4.3
 
+case $(uname -s) in
+	[Mm][Ii][Nn][Gg][Ww]*)
+		LN=mingw_ln
+		;;
+	*)
+		LN=unix_ln
+		;;
+esac
+
 usage()
 {
 
@@ -151,8 +160,26 @@ link()
 		rm -- "$GOAT_PATH/$1"
 	fi
 
-	ln -fs -- "$targetpath" "$GOAT_PATH/$1"
+	$LN "$targetpath" "$GOAT_PATH/$1"
 }
+
+unix_ln()
+{
+	targetpath="$1"
+	destination="$2"
+	ln -fs -- "$targetpath" "$destination"
+}
+
+mingw_ln()
+{
+	targetpath="$1"
+	destination="$2"
+	#cmd "$destination" "$targetpath"
+	"$GOAT_PATH/mingw_ln.bat" "$destination" "$targetpath"
+exit
+EOF
+}
+
 
 list()
 {

--- a/mingw_ln.bat
+++ b/mingw_ln.bat
@@ -1,0 +1,14 @@
+@echo off
+set LINK=%1
+set TARGET=%2
+
+REM Convert POSIX paths to Windows paths
+set LINK=%LINK:/=\%
+set TARGET=%TARGET:/=\%
+
+mklink /D %LINK% %TARGET% >NUL
+REM mklink requires admin privileges, so it doesn't work in all cases
+REM
+REM Should we use directiory junctions (/J) instead of symlinks (/D)?
+REM Junctions are more robust (e.g. when following symlinks over a
+REM remote share), but symlinks seem to work in more cases

--- a/setup
+++ b/setup
@@ -50,6 +50,18 @@ errxit()
 	exit 1
 }
 
+isMinGW()
+{
+	case $(uname -s) in
+		[Mm][Ii][Nn][Gg][Ww]*)
+			true
+			;;
+		*)
+			false
+			;;
+	esac
+}
+
 usage()
 {
 
@@ -106,7 +118,10 @@ mkdir -p "$destdir"
 mkdir -p "$GOAT_PATH"
 cp "$goat" "$destdir"
 cp "$libgoat" "$GOAT_PATH"
-cp "$mingw_ln" "$GOAT_PATH"
+if isMinGW
+then
+	cp "$mingw_ln" "$GOAT_PATH"
+fi
 
 if ! grep ". $GOAT_PATH/libgoat.sh" "$shellrc" 2>/dev/null 1>&2
 then

--- a/setup
+++ b/setup
@@ -38,6 +38,7 @@ GOAT_PATH="$default_goat_path"
 destdir="$HOME/bin"
 goat="$PWD/goat"
 libgoat="$PWD/libgoat.sh"
+mingw_ln="$PWD/mingw_ln.bat"
 shellrc="$HOME/.bashrc"
 tmpshellrc="$PWD/$(basename -- "$shellrc").tmp"
 
@@ -105,6 +106,7 @@ mkdir -p "$destdir"
 mkdir -p "$GOAT_PATH"
 cp "$goat" "$destdir"
 cp "$libgoat" "$GOAT_PATH"
+cp "$mingw_ln" "$GOAT_PATH"
 
 if ! grep ". $GOAT_PATH/libgoat.sh" "$shellrc" 2>/dev/null 1>&2
 then


### PR DESCRIPTION
Use `cmd /c mklink /D` instead of ln on MinGW systems. This uses a
helper batch script to get the arguments passed correctly through
MinGW's path-mangling.

On MinGW, ln is implemented as a copy function. which defeats the intent
of the command. Unfortunately, mklink requires admin privileges on
Windows, but at least that will work in more cases than the previous
version.