### PR TITLE
setup: Work from any CWD

### DIFF
--- a/setup
+++ b/setup
@@ -31,15 +31,16 @@
 set -eu
 
 # Configuration.
+workingdir="$(dirname -- "$0")"
 bashcompletiondir="$HOME/.bash_completion.d"
-bashcompletionfile="$PWD/goat.bash_completion"
+bashcompletionfile="$workingdir/goat.bash_completion"
 default_goat_path="$HOME/.goat"
 GOAT_PATH="$default_goat_path"
 destdir="$HOME/bin"
-goat="$PWD/goat"
-libgoat="$PWD/libgoat.sh"
+goat="$workingdir/goat"
+libgoat="$workingdir/libgoat.sh"
 shellrc="$HOME/.bashrc"
-tmpshellrc="$PWD/$(basename -- "$shellrc").tmp"
+tmpshellrc="$workingdir/$(basename -- "$shellrc").tmp"
 
 errxit()
 {
@@ -53,7 +54,7 @@ usage()
 {
 
 	cat <<EOF
-Usage: ./setup [-d|-h|-p|-s]
+Usage: $0 [-d|-h|-p|-s]
 
 Options:
     -b, --bash-completion DIR


### PR DESCRIPTION
Regardless of where setup is called from, it should behave the same. It
can do this by pulling its own working directory from $0, instead of
from $PWD.